### PR TITLE
Add Openwork to Autonomous Web Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ AI agents that autonomously navigate and interact with the web through a user-fr
 - [Nanobrowser](https://nanobrowser.ai) - An open-source & local-first AI web agent Chrome extension with flexible LLM options and multi-agent system. ![GitHub Repo stars](https://img.shields.io/github/stars/nanobrowser/nanobrowser?style=social)
 - [Browserable](https://browserable.ai) - An open-source & self-hostable browser automation library for AI agents. ![GitHub Repo stars](https://img.shields.io/github/stars/browserable/browserable?style=social)
 - [Tongyi WebAgent](https://github.com/Alibaba-NLP/WebAgent) - WebAgent for information seeking built by Tongyi Lab, Alibaba Group. ![GitHub Repo stars](https://img.shields.io/github/stars/Alibaba-NLP/WebAgent?style=social)
+- [Openwork](https://github.com/accomplish-ai/openwork) - An MIT-licensed, open alternative to Anthropic's Cowork built with Opencode and dev-browser. Supports multiple LLM providers for launching computer-use agents to automate browser workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/accomplish-ai/openwork?style=social)
 - [Dassi](https://www.dassi.ai/) - An AI coworking agent in your browser that automates tasks, navigates pages, and works with files and 2000+ apps from a side panel.
 
 ### Computer-use Agents


### PR DESCRIPTION
## Summary
- Adds [Openwork](https://github.com/accomplish-ai/openwork) to the Autonomous Web Agents section

## About Openwork
Openwork is an MIT-licensed, open alternative to Anthropic's Cowork, built using [Opencode](https://github.com/anomalyco/opencode) and [dev-browser](https://github.com/SawyerHood/dev-browser). It supports multiple LLM providers and lets users launch computer-use agents to automate real browser workflows—faster, safer, and fully open source.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)