### PR TITLE
Add Adapt or Die

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,7 @@ Resources for learning how to build, deploy, or utilize AI web agents.
 - [Build an AI Browser Agent](https://dzone.com/articles/build-ai-browser-agent-llms-playwright-browser-use) - Step-by-step guide to create an AI that browses the web using Playwright and the Browser-Use library.
 - [Install & Run Browser-Use Locally](https://aleksandarhaber.com/install-and-run-browser-use-ai-agents-locally-using-ollama/) - Instructions on installing the open-source Browser-Use agent with a local LLM.
 - [Build a Browser Agent with DeepSeek](https://nodeshift.com/blog/build-a-browser-use-agent-with-deepseek-a-step-by-step-guide) - Walks through deploying a Browser-Use web UI agent powered by the DeepSeek model on a cloud VM.
+- [Adapt or Die](https://adaptordie.io) - Independent editorial covering agentic commerce, AI agents in ecommerce, and digital transformation. Sharp analysis, no AI slop.
 
 <!-- END CONTENT -->
 


### PR DESCRIPTION
Adding Adapt or Die (https://adaptordie.io) — independent editorial covering agentic commerce and AI's impact on ecommerce. Regular analysis of how AI agents are reshaping online retail, supply chains, and digital operations.