### PR TITLE
Add Lumen — vision-first browser agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) - Experimental agent for task completion and web browsing. ![GitHub Repo stars](https://img.shields.io/github/stars/Significant-Gravitas/AutoGPT?style=social)
 - [TinyFish](https://www.tinyfish.ai) - Remote web agents that execute tasks on any website and return structured JSON via a single API call. ![GitHub Repo stars](https://img.shields.io/github/stars/tinyfish-io/tinyfish-cookbook?style=social)
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - Containerized computer use agent framework with a virtual desktop environment. ![GitHub Repo stars](https://img.shields.io/github/stars/bytebot-ai/bytebot?style=social)
+- [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider (Anthropic, Google, OpenAI), action caching for zero-token reruns. ![GitHub Repo stars](https://img.shields.io/github/stars/omxyz/lumen?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Add Lumen to Computer-use Agents

[Lumen](https://github.com/omxyz/lumen) is a vision-first browser agent with self-healing deterministic replay.

- **Vision-only loop** — screenshot → model → action → repeat over CDP. No DOM, no selectors.
- **Multi-provider** — Anthropic, Google, OpenAI, and any OpenAI-compatible endpoint.
- **Self-healing action cache** — replay cached actions, fall back to model on failure, auto-update stale entries.
- **100% on WebVoyager** 25-task subset (Claude Sonnet).

- [npm](https://www.npmjs.com/package/@omxyz/lumen)
- [Docs](https://lumen.omlabs.xyz)

### Category
Computer-use Agents