### PR TITLE
Added the TimeWarp benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Datasets, benchmarks, and notable research efforts for evaluating and advancing 
 - [WebVoyager (Benchmark)](https://arxiv.org/abs/2401.13919) - Vision-enabled benchmark for real-world website interaction with large multimodal models. ![GitHub Repo stars](https://img.shields.io/github/stars/MinorJerry/WebVoyager?style=social)
 - [WorkArena](https://github.com/ServiceNow/WorkArena) - A suite of 33 browser-based tasks for enterprise "knowledge worker" scenarios. ![GitHub Repo stars](https://img.shields.io/github/stars/ServiceNow/WorkArena?style=social)
 - [BrowserGym by ServiceNow](https://github.com/ServiceNow/BrowserGym) - A gym environment for web task automation. ![GitHub Repo stars](https://img.shields.io/github/stars/ServiceNow/BrowserGym?style=social)
+- [TimeWarp](https://timewarp-web.github.io) - A benchmark on historical versions of web UI.
 
 ## Tutorials & Guides
 


### PR DESCRIPTION
<!--
For new items, title the PR as:
Add: TimeWarp benchmark

For archival moves, title the PR as:
Archive: item-name
-->

## Summary

TimeWarp is a benchmark for evaluating web agents on varying versions of web UI across different eras of the internet.

## Item

- Name: TimeWarp: Evaluating Web Agents by Revisiting the Past
- Link: https://timewarp-web.github.io/

## Section

Benchmarks & Research

## Why this belongs

Evaluates the vulnerability of web agents across UI changes

## Primary documented web-agent use case

Project Page: https://timewarp-web.github.io/
Paper: https://arxiv.org/abs/2603.04949
Code: https://github.com/sparklabutah/timewarp

## Public reference

https://arxiv.org/abs/2603.04949

## Affiliation disclosure

Yes, I am one of the authors.

## Checklist

- [ X ] This PR adds exactly one item.
- [ X ] I added the item to the bottom of the best-fit section.
- [ X ] The description is factual, neutral, and ends with a period.
- [ X ] This is directly relevant to web agents, not just AI tooling in general.
- [ X ] I checked for duplicates before submitting.
