### PR TITLE
Add: BabelWrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [TinyFish](https://www.tinyfish.ai) - Remote web agents that execute tasks on any website and return structured JSON via a single API call. ![GitHub Repo stars](https://img.shields.io/github/stars/tinyfish-io/tinyfish-cookbook?style=social)
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - Containerized computer use agent framework with a virtual desktop environment. ![GitHub Repo stars](https://img.shields.io/github/stars/bytebot-ai/bytebot?style=social)
 - [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider (Anthropic, Google, OpenAI), action caching for zero-token reruns. ![GitHub Repo stars](https://img.shields.io/github/stars/omxyz/lumen?style=social)
+- [BabelWrap](https://babelwrap.com) - HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/babelwrap/babelwrap-mcp?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## What section does this belong in?

Dev Tools

## Why does it belong on this list?

BabelWrap is an HTTP API and MCP server that lets AI agents interact with any website through natural language descriptions instead of CSS selectors. Agents describe actions in plain English (e.g., "click the Login button", "fill the email field", "extract all product prices") and BabelWrap translates these into real browser interactions, returning structured LLM-readable snapshots. It provides 18 MCP tools and a Python SDK.

## What is its primary documented use case?

Enabling AI agents (Claude, GPT-4, etc.) to navigate, interact with, and extract data from websites via natural language commands — used for web research, form automation, data extraction, and multi-site workflows.

## Public reference

- Website: https://babelwrap.com
- MCP Docs: https://babelwrap.com/docs/mcp
- PyPI (SDK): https://pypi.org/project/babelwrap/
- PyPI (MCP): https://pypi.org/project/babelwrap-mcp/
- GitHub: https://github.com/babelwrap/babelwrap-mcp

## Affiliation disclosure

I am the creator of BabelWrap.