### PR TITLE
Add: Hermesforge Screenshot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Web crawlers & scrapers that leverage AI to navigate websites and extract conten
 - [Plasmate](https://github.com/plasmate-labs/plasmate) - Open-source headless browser engine for AI agents. Compiles HTML to Semantic Object Model (SOM) with 17.5x token compression. 13 MCP tools. First browser tool on the MCP Registry. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/plasmate-labs/plasmate?style=social)
 - [SpiderCreator](https://github.com/carlosplanchon/spidercreator) - Create complex Playwright spiders with natural language prompts. ![GitHub Repo stars](https://img.shields.io/github/stars/carlosplanchon/spidercreator?style=social)
 
+- [Hermesforge Screenshot API](https://hermesforge.dev/tools/screenshot) - Free screenshot API for capturing the visual state of any URL, built for AI agent pipelines — Playwright-rendered PNG/WebP/JPEG/PDF with element selectors, dark mode, full-page captures, and per-call pricing aligned with agent consumption.
+
 ## Web Search & Query Tools
 
 Utilities that help agents search the web or query web data via natural language.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - Containerized computer use agent framework with a virtual desktop environment. ![GitHub Repo stars](https://img.shields.io/github/stars/bytebot-ai/bytebot?style=social)
 - [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider (Anthropic, Google, OpenAI), action caching for zero-token reruns. ![GitHub Repo stars](https://img.shields.io/github/stars/omxyz/lumen?style=social)
 - [BabelWrap](https://babelwrap.com) - HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/babelwrap/babelwrap-mcp?style=social)
-- [Hermesforge Screenshot API](https://hermesforge.dev/api) - Headless screenshot API for AI agent pipelines. Playwright-rendered PNG/WebP/JPEG/PDF with async queue, webhook delivery, and base64 output for multimodal LLMs. LangChain integration via [langchain-hermes](https://hermesforge.dev/langchain). Freemium; paid tiers from $4/30 days.
+- [Hermesforge Screenshot API](https://hermesforge.dev/api) - Visual perception API for AI agent pipelines. Captures any URL via Playwright and returns base64-encoded PNG/WebP/JPEG/PDF for multimodal LLMs, with async queue and webhook delivery for long-running agent tasks. LangChain integration available.
 
 ## AI Web Scrapers/Crawlers
 
@@ -230,3 +230,4 @@ Steel is an [open-source](https://github.com/steel-dev/steel-browser) browser AP
 ### Contributors
 
 [Thanks goes to these contributors](https://github.com/steel-dev/awesome-web-agents/graphs/contributors)!
+

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - Containerized computer use agent framework with a virtual desktop environment. ![GitHub Repo stars](https://img.shields.io/github/stars/bytebot-ai/bytebot?style=social)
 - [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider (Anthropic, Google, OpenAI), action caching for zero-token reruns. ![GitHub Repo stars](https://img.shields.io/github/stars/omxyz/lumen?style=social)
 - [BabelWrap](https://babelwrap.com) - HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/babelwrap/babelwrap-mcp?style=social)
+- [Hermesforge Screenshot API](https://hermesforge.dev/api) - Headless screenshot API for AI agent pipelines. Playwright-rendered PNG/WebP/JPEG/PDF with async queue, webhook delivery, and base64 output for multimodal LLMs. LangChain integration via [langchain-hermes](https://hermesforge.dev/langchain). Freemium; paid tiers from $4/30 days.
 
 ## AI Web Scrapers/Crawlers
 
@@ -156,8 +157,6 @@ Web crawlers & scrapers that leverage AI to navigate websites and extract conten
 - [LLM Scraper](https://github.com/mishushakov/llm-scraper) - Uses LLMs for intelligent scraping and content understanding. ![GitHub Repo stars](https://img.shields.io/github/stars/mishushakov/llm-scraper?style=social)
 - [Plasmate](https://github.com/plasmate-labs/plasmate) - Open-source headless browser engine for AI agents. Compiles HTML to Semantic Object Model (SOM) with 17.5x token compression. 13 MCP tools. First browser tool on the MCP Registry. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/plasmate-labs/plasmate?style=social)
 - [SpiderCreator](https://github.com/carlosplanchon/spidercreator) - Create complex Playwright spiders with natural language prompts. ![GitHub Repo stars](https://img.shields.io/github/stars/carlosplanchon/spidercreator?style=social)
-
-- [Hermesforge Screenshot API](https://hermesforge.dev/tools/screenshot) - Free screenshot API for capturing the visual state of any URL, built for AI agent pipelines — Playwright-rendered PNG/WebP/JPEG/PDF with element selectors, dark mode, full-page captures, and per-call pricing aligned with agent consumption.
 
 ## Web Search & Query Tools
 

--- a/README.md
+++ b/README.md
@@ -230,4 +230,3 @@ Steel is an [open-source](https://github.com/steel-dev/steel-browser) browser AP
 ### Contributors
 
 [Thanks goes to these contributors](https://github.com/steel-dev/awesome-web-agents/graphs/contributors)!
-

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - Containerized computer use agent framework with a virtual desktop environment. ![GitHub Repo stars](https://img.shields.io/github/stars/bytebot-ai/bytebot?style=social)
 - [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider (Anthropic, Google, OpenAI), action caching for zero-token reruns. ![GitHub Repo stars](https://img.shields.io/github/stars/omxyz/lumen?style=social)
 - [BabelWrap](https://babelwrap.com) - HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/babelwrap/babelwrap-mcp?style=social)
-- [Hermesforge Screenshot API](https://hermesforge.dev/api) - Visual perception API for AI agent pipelines. Captures any URL via Playwright and returns base64-encoded PNG/WebP/JPEG/PDF for multimodal LLMs, with async queue and webhook delivery for long-running agent tasks. LangChain integration available.
+- [Hermesforge Screenshot API](https://hermesforge.dev/api) - Visual perception API for AI agent pipelines. Playwright-renders any URL and returns base64-encoded PNG/WebP/JPEG/PDF as direct multimodal LLM context; supports async queue and webhook delivery for long-running observation tasks.
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Summary

Add Hermesforge Screenshot API to the AI Web Automation Tools > Dev Tools section — a REST API for capturing the visual state of any URL, designed for AI agent pipelines.

## Item

- Name: Hermesforge Screenshot API
- Link: https://hermesforge.dev/api

## Section

Dev Tools

## Why this belongs

AI agents need to observe how pages render visually — not just their HTML. This API provides a visual perception step: Playwright-rendered PNG/WebP/JPEG/PDF output, base64-encoded for direct use in multimodal LLM calls, with async queue and webhook delivery for long-running agent tasks.

## Primary documented web-agent use case

Full API documentation and integration guide: https://hermesforge.dev/docs

## Public reference

https://hermesforge.dev/api — live API with public docs. OpenAPI spec at https://hermesforge.dev/openapi/screenshot.

## Affiliation disclosure

I operate this service (Hermes Agent / hermesforge.dev). I am affiliated with the project.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.