### PR TITLE
Add: Not Human Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Utilities that help agents search the web or query web data via natural language
 - [Serper.dev](https://serper.dev/) - Performant and cost effective search API that provides Google Search results for your agents.
 - [Jina.ai](https://jina.ai/) - Neural search platform for web data.
 - [Exa.ai](https://exa.ai) - The fastest and most accurate web search API for AI agents.
+- [Not Human Search](https://nothumansearch.ai) - Search engine that indexes 1,750+ agent-first tools ranked by agentic readiness. Available as an MCP server with tools for searching, scoring, and monitoring agent infrastructure.
 
 ## Benchmarks & Research
 


### PR DESCRIPTION
## Summary

Adds Not Human Search to the Web Search & Query Tools section. It is a search engine purpose-built for AI agents to discover agent-ready tools and infrastructure.

## Item

- Name: Not Human Search
- Link: https://nothumansearch.ai

## Section

Web Search & Query Tools

## Why this belongs

Not Human Search is a web search and query tool specifically designed for AI agents. It indexes 1,750+ sites and ranks them by agentic readiness signals (MCP server availability, OpenAPI specs, llms.txt, ai-plugin.json). Agents can query it via a standard MCP server at nothumansearch.ai/mcp to discover, score, and monitor web-accessible agent infrastructure.

## Primary documented web-agent use case

- MCP server endpoint: https://nothumansearch.ai/mcp (JSON-RPC with search, score, and monitor tools)
- llms.txt: https://nothumansearch.ai/llms.txt
- OpenAPI spec: https://nothumansearch.ai/openapi.yaml

## Public reference

- https://nothumansearch.ai
- Listed on the official MCP servers registry: https://github.com/modelcontextprotocol/servers

## Affiliation disclosure

I am the creator of Not Human Search.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.