### PR TITLE
Add: BrowserTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider (Anthropic, Google, OpenAI), action caching for zero-token reruns. ![GitHub Repo stars](https://img.shields.io/github/stars/omxyz/lumen?style=social)
 - [BabelWrap](https://babelwrap.com) - HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/babelwrap/babelwrap-mcp?style=social)
 - [Hermesforge Screenshot API](https://hermesforge.dev/api) - Visual perception API for AI agent pipelines. Playwright-renders any URL and returns base64-encoded PNG/WebP/JPEG/PDF as direct multimodal LLM context; supports async queue and webhook delivery for long-running observation tasks.
+- [BrowserTrace](https://github.com/aaronlab/browsertrace) - Local-first trace viewer for debugging Playwright, Browser Use, Stagehand, and other web-agent runs with redacted shareable exports. ![GitHub Repo stars](https://img.shields.io/github/stars/aaronlab/browsertrace?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Summary

Add BrowserTrace as a local-first debugging trace viewer for AI web-agent runs.

## Item

- Name: BrowserTrace
- Link: https://github.com/aaronlab/browsertrace

## Section

Dev Tools

## Why this belongs

BrowserTrace directly supports operating and debugging web agents by recording Playwright, Browser Use, Stagehand, Skyvern-shaped, and generic computer-use runs, then exposing failed steps through a local trace viewer and redacted shareable exports.

## Primary documented web-agent use case

https://github.com/aaronlab/browsertrace#readme

## Public reference

https://github.com/aaronlab/browsertrace

## Affiliation disclosure

I am affiliated with BrowserTrace: I maintain it under the aaronlab account.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.

Local verification:
- `GITHUB_TOKEN=$(gh auth token) npx -y awesome-lint@2.2.3 README.md` -> passed.
- `/Users/enyuanzhang/.gem/ruby/2.6.0/bin/awesome_bot --allow-dupe --allow-redirect --white-list "https://github.com/steel-dev/awesome-web-agents,https://surf.new,https://openai.com/index/introducing-operator/,https://www.perplexity.ai/comet,https://openai.com/research/webgpt,https://dzone.com/articles/build-ai-browser-agent-llms-playwright-browser-use,https://dev.to/nodeshiftcloud/build-a-browser-use-agent-with-deepseek-a-step-by-step-guide-2n59" README.md` -> No issues.
- `git diff --check` -> clean.