### PR TITLE
Add invisible-playwright to Dev Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay. Screenshot → model → action loop over CDP, multi-provider (Anthropic, Google, OpenAI), action caching for zero-token reruns. ![GitHub Repo stars](https://img.shields.io/github/stars/omxyz/lumen?style=social)
 - [BabelWrap](https://babelwrap.com) - HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/babelwrap/babelwrap-mcp?style=social)
 - [Hermesforge Screenshot API](https://hermesforge.dev/api) - Visual perception API for AI agent pipelines. Playwright-renders any URL and returns base64-encoded PNG/WebP/JPEG/PDF as direct multimodal LLM context; supports async queue and webhook delivery for long-running observation tasks.
+- [invisible-playwright](https://github.com/feder-cr/invisible_playwright) - Playwright wrapper for a stealth-patched Firefox 150 build. Drop-in replacement returning native Playwright Browser objects, spoofing happens in C++ source with no JS-level overrides. ![GitHub Repo stars](https://img.shields.io/github/stars/feder-cr/invisible_playwright?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
A Playwright drop-in that swaps the vanilla Firefox launch for a stealth-patched Firefox 150 binary. The returned object is a native `playwright.sync_api.Browser` / `async_api.Browser`, so existing agent code (LangChain Playwright Toolkit, Stagehand, browser-use) keeps working unchanged.

Anti-fingerprinting is in the C++ source (Canvas, WebGL, AudioContext, Fonts, WebRTC, Timezone, DevTools detection) driven by ~24 preferences. Useful when agents need to scrape sites guarded by reCAPTCHA v3 / FingerprintPro without falling back to commercial SaaS browsers.

Repo: https://github.com/feder-cr/invisible_playwright
Patches: https://github.com/feder-cr/firefox-stealth