### PR TITLE
Add: APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Tools, frameworks and libraries that translate natural language instructions int
 
 ### Dev Tools
 
+- [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) - Runtime policy guardrails for AI/browser agents, with pre-action authorization hooks and local or API enforcement for risky tool calls.
+
 - [Steel.dev](https://steel.dev) - Open-source headless browser API built specifically for AI agents and apps. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)
 - [Omniparser](https://microsoft.github.io/OmniParser/) - Tool for parsing GUIs for vision based agents. ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/OmniParser?style=social)
 - [LaVague](https://www.lavague.ai/) - Framework for natural language web automation. ![GitHub Repo stars](https://img.shields.io/github/stars/lavague-ai/LaVague?style=social)


### PR DESCRIPTION
## Summary
Adds APort Agent Guardrails as a runtime guardrail tool for AI agents before they execute risky browser or tool actions.

## Item
- Name: APort Agent Guardrails
- Link: https://github.com/aporthq/aport-agent-guardrails

## Section
Dev Tools

## Why this belongs
APort helps operate agentic systems more safely by adding pre-action authorization, blocked-pattern checks, and policy enforcement before an agent proceeds with tool calls.

## Primary documented web-agent use case
The repository documents OpenClaw integration and a before_tool_call hook for agent tool execution: https://github.com/aporthq/aport-agent-guardrails

## Public reference
https://github.com/aporthq/aport-agent-guardrails

## Affiliation disclosure
Submitting this as part of an APort awareness bounty; no maintainer affiliation with this awesome list.

## Checklist
- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.