### PR TITLE
Update: ClawBench entry — V2 corpus (283 tasks, 163 platforms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Datasets, benchmarks, and notable research efforts for evaluating and advancing 
 - [WorkArena](https://github.com/ServiceNow/WorkArena) - A suite of 33 browser-based tasks for enterprise "knowledge worker" scenarios. ![GitHub Repo stars](https://img.shields.io/github/stars/ServiceNow/WorkArena?style=social)
 - [BrowserGym by ServiceNow](https://github.com/ServiceNow/BrowserGym) - A gym environment for web task automation. ![GitHub Repo stars](https://img.shields.io/github/stars/ServiceNow/BrowserGym?style=social)
 - [TimeWarp](https://timewarp-web.github.io) - A benchmark on historical versions of web UI.
-- [ClawBench](https://github.com/reacher-z/ClawBench) - 153 everyday tasks on 144 live production websites across 15 categories, with a submission-interception layer that blocks only the final write request to preserve real-site behavior without side effects. ![GitHub Repo stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)
+- [ClawBench](https://github.com/reacher-z/ClawBench) - 283 everyday tasks (V1 153 + V2 130) on 163 live production websites across 15 categories. Two-stage scoring (final HTTP-request interception + LLM judge) blocks only the write request so real sites stay clean. Public leaderboard with 5-layer execution traces (recording, action log, request log, agent messages, interception). ![GitHub Repo stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)
 
 ## Tutorials & Guides
 


### PR DESCRIPTION
ClawBench is already in the Benchmarks & Research section, but the blurb
is from the V1 release. This PR refreshes it to reflect the V2 corpus
that shipped last week.

**What changed since the entry was added:**

- Task count: 153 → **283** (V1 153 + V2 130)
- Platforms covered: 144 → **163**
- Scoring: was just HTTP-request interception; now a **two-stage
  pipeline** — Stage 1 final-request interception, Stage 2 LLM-judge
  reviews the intercepted body. This addresses the "agent reached the
  endpoint but submitted the wrong thing" failure mode.
- Public leaderboard at https://claw-bench.com with 6 tabs by corpus ×
  harness pairing.
- All eval runs come with a 5-layer execution-trace bundle (recording,
  action log, request log, agent messages, interception JSON) — useful
  for anyone who wants to audit, debug, or build on top of the runs.

No other entries touched.