### PR TITLE
Add: TheCrawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Web crawlers & scrapers that leverage AI to navigate websites and extract conten
 - [LLM Scraper](https://github.com/mishushakov/llm-scraper) - Uses LLMs for intelligent scraping and content understanding. ![GitHub Repo stars](https://img.shields.io/github/stars/mishushakov/llm-scraper?style=social)
 - [Plasmate](https://github.com/plasmate-labs/plasmate) - Open-source headless browser engine for AI agents. Compiles HTML to Semantic Object Model (SOM) with 17.5x token compression. 13 MCP tools. First browser tool on the MCP Registry. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/plasmate-labs/plasmate?style=social)
 - [SpiderCreator](https://github.com/carlosplanchon/spidercreator) - Create complex Playwright spiders with natural language prompts. ![GitHub Repo stars](https://img.shields.io/github/stars/carlosplanchon/spidercreator?style=social)
+- [TheCrawler](https://github.com/manchittlab/TheCrawler) - GitHub-source MCP server and CLI for web crawling, extraction diagnostics, and validated extraction contracts. ![GitHub Repo stars](https://img.shields.io/github/stars/manchittlab/TheCrawler?style=social)
 
 ## Web Search & Query Tools
 


### PR DESCRIPTION
## Summary

Adds TheCrawler as one neutral item in the AI Web Scrapers/Crawlers section.

## Item

- Name: TheCrawler
- Link: https://github.com/manchittlab/TheCrawler

## Section

AI Web Scrapers/Crawlers

## Why this belongs

TheCrawler directly supports web-agent workflows by exposing a GitHub-source MCP server and CLI for crawling, extraction diagnostics, and validated extraction contracts.

## Primary documented web-agent use case

https://github.com/manchittlab/TheCrawler#validated-extraction-contracts

## Public reference

https://github.com/manchittlab/TheCrawler

## Affiliation disclosure

I am affiliated with the project.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.