### PR TITLE
Add: DataLens

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Web crawlers & scrapers that leverage AI to navigate websites and extract conten
 - [LLM Scraper](https://github.com/mishushakov/llm-scraper) - Uses LLMs for intelligent scraping and content understanding. ![GitHub Repo stars](https://img.shields.io/github/stars/mishushakov/llm-scraper?style=social)
 - [Plasmate](https://github.com/plasmate-labs/plasmate) - Open-source headless browser engine for AI agents. Compiles HTML to Semantic Object Model (SOM) with 17.5x token compression. 13 MCP tools. First browser tool on the MCP Registry. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/plasmate-labs/plasmate?style=social)
 - [SpiderCreator](https://github.com/carlosplanchon/spidercreator) - Create complex Playwright spiders with natural language prompts. ![GitHub Repo stars](https://img.shields.io/github/stars/carlosplanchon/spidercreator?style=social)
+- [DataLens](https://datalens.uk) - AI web data agent that plans browser scraping tasks, extracts structured web data, and exposes MCP tools for dataset workflows.
 
 ## Web Search & Query Tools
 


### PR DESCRIPTION
## Summary

Adds DataLens to AI Web Scrapers/Crawlers as an AI web data agent for browser-based scraping, structured extraction, dataset export, and MCP-connected dataset workflows.

## Item

- Name: DataLens
- Link: https://datalens.uk

## Section

AI Web Scrapers/Crawlers

## Why this belongs

DataLens directly supports web-agent workflows by turning user-described browser scraping tasks into structured web data extraction and export flows. It also publishes an MCP server package for agent/tool access to DataLens workflows.

## Primary documented web-agent use case

- https://datalens.uk
- https://chromewebstore.google.com/detail/datalens/knibjebonijofbecjbdclgpnblgiakcc
- https://www.npmjs.com/package/datalens-mcp-server

## Public reference

- https://datalens.uk
- https://chromewebstore.google.com/detail/datalens/knibjebonijofbecjbdclgpnblgiakcc

## Affiliation disclosure

I am affiliated with the DataLens project.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.
