### PR TITLE
Add Future AGI traceAI and simulate-sdk to Dev Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Notte](https://notte.cc) - Browser infrastructure for AI agents with managed sessions, an agent runtime, and credential vault and persona authentication primitives. ![GitHub Repo stars](https://img.shields.io/github/stars/nottelabs/notte?style=social)
 - [invisible-playwright](https://github.com/feder-cr/invisible_playwright) - Playwright wrapper for a stealth-patched Firefox 150 build. Drop-in replacement returning native Playwright Browser objects; spoofing happens in C++ source with no JS-level overrides. ![GitHub Repo stars](https://img.shields.io/github/stars/feder-cr/invisible_playwright?style=social)
 - [Webwright](https://github.com/microsoft/Webwright) - Browser agent framework from Microsoft Research where the agent writes and runs Playwright scripts in a terminal workspace; supports OpenAI, Anthropic, and OpenRouter backends. ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/Webwright?style=social)
+- [traceAI](https://github.com/future-agi/traceAI) - Open-source OpenTelemetry-native tracing for LLM and agent apps. Auto-instruments 50+ frameworks across Python, TypeScript, Java, and C# (OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, Bedrock). No vendor lock-in. ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/traceAI?style=social)
+- [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk) - Open-source SDK for simulating voice and text AI agents through persona- and scenario-driven multi-turn conversations before launch. ![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/simulate-sdk?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
This PR adds open-source Future AGI projects to the most relevant section(s) of the list.

All entries are Apache 2.0 licensed.

- traceAI: https://github.com/future-agi/traceAI
- ai-evaluation: https://github.com/future-agi/ai-evaluation
- agent-opt: https://github.com/future-agi/agent-opt
- simulate-sdk: https://github.com/future-agi/simulate-sdk
- agent-command-center-sdk: https://github.com/future-agi/agent-command-center-sdk
- future-agi (umbrella): https://github.com/future-agi/future-agi
- futureagi-mcp-server: https://github.com/future-agi/futureagi-mcp-server

Description style and placement match the existing entries in the chosen section. Single-purpose diff: only README updates.