### PR TITLE
Add: web-search-autogen-guide (Superhighway x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Resources for learning how to build, deploy, or utilize AI web agents.
 - [Build an AI Browser Agent](https://dzone.com/articles/build-ai-browser-agent-llms-playwright-browser-use) - Step-by-step guide to create an AI that browses the web using Playwright and the Browser-Use library.
 - [Install & Run Browser-Use Locally](https://aleksandarhaber.com/install-and-run-browser-use-ai-agents-locally-using-ollama/) - Instructions on installing the open-source Browser-Use agent with a local LLM.
 - [Build a Browser Agent with DeepSeek](https://dev.to/nodeshiftcloud/build-a-browser-use-agent-with-deepseek-a-step-by-step-guide-2n59) - Walks through deploying a Browser-Use web UI agent powered by the DeepSeek model on a cloud VM.
+- [Web Search in AutoGen Agents (x402 Pay-Per-Call)](https://superhighway.walls.sh/guides/web-search-autogen) - Adds live web search to AutoGen 0.4+ agents via a USDC pay-per-call API, covering both MCP tool and inline function-tool paths.
 
 ## Archive
 


### PR DESCRIPTION
## What is being added

A tutorial in the **Tutorials & Guides** section:

> **[Web Search in AutoGen Agents (x402 Pay-Per-Call)](https://superhighway.walls.sh/guides/web-search-autogen)** — Adds live web search to AutoGen 0.4+ agents via a USDC pay-per-call API, covering both MCP tool and inline function-tool paths.

## Section fit

**Tutorials & Guides** — the guide teaches how to equip an AutoGen agent with live web search capability, which is directly an AI web agent use case. AutoGen's own MultimodalWebSurfer is already listed under Autonomous Web Agents in this repo.

## Public references

- Guide: https://superhighway.walls.sh/guides/web-search-autogen
- API docs: https://superhighway.walls.sh

## Affiliation disclosure

I work on Superhighway (the web search API referenced in this guide).