### PR TITLE
Add Agent Browser Shield to Dev Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [invisible-playwright](https://github.com/feder-cr/invisible_playwright) - Playwright wrapper for a stealth-patched Firefox 150 build. Drop-in replacement returning native Playwright Browser objects; spoofing happens in C++ source with no JS-level overrides. ![GitHub Repo stars](https://img.shields.io/github/stars/feder-cr/invisible_playwright?style=social)
 - [Webwright](https://github.com/microsoft/Webwright) - Browser agent framework from Microsoft Research where the agent writes and runs Playwright scripts in a terminal workspace; supports OpenAI, Anthropic, and OpenRouter backends. ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/Webwright?style=social)
 - [BrowserAct](https://github.com/browser-act/skills) - Browser automation CLI and skills for AI agents to operate real browsers, manage sessions, support human handoff, and capture screenshots and evidence. ![GitHub Repo stars](https://img.shields.io/github/stars/browser-act/skills?style=social)
+- [Agent Browser Shield](https://github.com/pixiebrix/agent-browser-shield) - Browser extension that sits between an AI agent and the page, stripping prompt injection, masking PII/credentials, and removing dark patterns before content reaches the model. ![GitHub Repo stars](https://img.shields.io/github/stars/pixiebrix/agent-browser-shield?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Item

- Name: Agent Browser Shield
- Link:https://github.com/pixiebrix/agent-browser-shield 

## Section

Choose one section name exactly as it appears in the repository:


- Dev Tools

## Why this belongs

Agent Browser Shield sits between an AI web agent and the pages it visits, processing the DOM before the agent's model ever sees it. It directly helps run and operate web agents in three ways: it strips prompt injection (hidden text and HTML comments) so a malicious page can't hijack the agent, masks PII and credentials before they reach the model, and removes dark patterns and page noise (cookie banners, ads, chat widgets), which also cuts token usage. It packages for Browserbase and installs alongside browser-use / OpenClaw agents, so it's infrastructure for anyone shipping agents that browse the web.

## Primary documented web-agent use case

Docs: https://pixiebrix.github.io/agent-browser-shield/ (install + runtime behavior for agents, including Browserbase and local CDP setups). Live demo of what it strips: https://shield-dark-pattern-demo.vercel.app/

## Public reference

GitHub repo: https://github.com/pixiebrix/agent-browser-shield (also on the Chrome Web Store: https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd)

## Affiliation disclosure

Yes, affiliated. I work at PixieBrix, the company that builds and maintains Agent Browser Shield. This project is free and source available and we aren't charging for it. It's a utility that was built based on learnings from other projects with browser automation.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.
