### PR TITLE
Add: HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Webwright](https://github.com/microsoft/Webwright) - Browser agent framework from Microsoft Research where the agent writes and runs Playwright scripts in a terminal workspace; supports OpenAI, Anthropic, and OpenRouter backends. ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/Webwright?style=social)
 - [BrowserAct](https://github.com/browser-act/skills) - Browser automation CLI and skills for AI agents to operate real browsers, manage sessions, support human handoff, and capture screenshots and evidence. ![GitHub Repo stars](https://img.shields.io/github/stars/browser-act/skills?style=social)
 - [Agent Browser Shield](https://github.com/pixiebrix/agent-browser-shield) - Browser extension that sits between an AI agent and the page, stripping prompt injection, masking PII/credentials, and removing dark patterns before content reaches the model. ![GitHub Repo stars](https://img.shields.io/github/stars/pixiebrix/agent-browser-shield?style=social)
+- [HUD](https://github.com/hud-evals/hud-python) - Open-source SDK for building browser and computer-use RL environments to evaluate and train web agents, with task-based verifiable rewards runnable as evals or RL training across any model. ![GitHub Repo stars](https://img.shields.io/github/stars/hud-evals/hud-python?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Summary

Adds HUD, an open-source SDK for building browser and computer-use RL environments to evaluate and train web agents, to the Dev Tools section.

## Item

- Name: HUD
- Link: https://github.com/hud-evals/hud-python

## Section

Dev Tools

## Why this belongs

HUD is an SDK you build web-agent tooling with: you define browser and computer-use environments (tools, tasks, scenarios), then run agents through them to evaluate and train. It sits alongside the other Dev Tools entries (Stagehand, LaVague, Bytebot, Webwright) as infrastructure for building and operating agents that browse and control the web, rather than a fixed benchmark.

## Primary documented web-agent use case

https://docs.hud.ai — building and running browser/computer-use environments where agents take actions (navigate, click, type) and are scored. Environments are MCP servers with native tool support for Claude, GPT, and Gemini computer-use.

## Public reference

https://github.com/hud-evals/hud-python (MIT, 269+ stars) and https://docs.hud.ai

## Affiliation disclosure

Yes — I'm affiliated with HUD.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.
