### PR TITLE
Add Skill Hub — 2800+ AI Agent Skills navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Tools, frameworks and libraries that translate natural language instructions int
 
 ### Dev Tools
 
+
+- [Skill Hub](https://skill.442595.xyz/) — 2800+ AI Agent Skills 分类导航站，支持多平台技能筛选
 - [Steel.dev](https://steel.dev) - Open-source headless browser API built specifically for AI agents and apps. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)
 - [Atlas](https://github.com/steel-dev/atlas) - Open-source deep research harness for building cited web research agents with ledger-based coverage audits, pluggable search providers, and Steel-backed browser fetches. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/atlas?style=social)
 - [Omniparser](https://microsoft.github.io/OmniParser/) - Tool for parsing GUIs for vision based agents. ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/OmniParser?style=social)


### PR DESCRIPTION
## 新增: Skill Hub

**描述**: 2800+ AI Agent Skills 分类导航站
- 2800+ AI Agent Skills & MCP Tools
- 按功能分类浏览
- 支持 Claude Code、Cursor、Codex、Hermes 等多平台筛选
- 在线访问: https://skill.442595.xyz/