### PR TITLE
 Add: Attest

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [BrowserAct](https://github.com/browser-act/skills) - Browser automation CLI and skills for AI agents to operate real browsers, manage sessions, support human handoff, and capture screenshots and evidence. ![GitHub Repo stars](https://img.shields.io/github/stars/browser-act/skills?style=social)
 - [Agent Browser Shield](https://github.com/pixiebrix/agent-browser-shield) - Browser extension that sits between an AI agent and the page, stripping prompt injection, masking PII/credentials, and removing dark patterns before content reaches the model. ![GitHub Repo stars](https://img.shields.io/github/stars/pixiebrix/agent-browser-shield?style=social)
 - [HUD](https://github.com/hud-evals/hud-python) - Open-source SDK for building browser and computer-use RL environments to evaluate and train web agents, with task-based verifiable rewards runnable as evals or RL training across any model. ![GitHub Repo stars](https://img.shields.io/github/stars/hud-evals/hud-python?style=social)
+- [Attest](https://github.com/Cyrus580529/Attest) - Trust layer for web agents: refs are validated against the live page before execution, writes are verified via snapshot diff, and outcomes are computed from an evidence ledger rather than the model's own claim.
 
 ## AI Web Scrapers/Crawlers
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [Agent Browser Shield](https://github.com/pixiebrix/agent-browser-shield) - Browser extension that sits between an AI agent and the page, stripping prompt injection, masking PII/credentials, and removing dark patterns before content reaches the model. ![GitHub Repo stars](https://img.shields.io/github/stars/pixiebrix/agent-browser-shield?style=social)
 - [HUD](https://github.com/hud-evals/hud-python) - Open-source SDK for building browser and computer-use RL environments to evaluate and train web agents, with task-based verifiable rewards runnable as evals or RL training across any model. ![GitHub Repo stars](https://img.shields.io/github/stars/hud-evals/hud-python?style=social)
 - [Webfuse](https://www.webfuse.com) - Configurable web proxy and browser-as-a-service for deploying and operating AI agents in a sandbox layer on top of any third-party website, using client-side extensions and without source-code access.
-- [Attest](https://github.com/Cyrus580529/Attest) - Trust layer for web agents: refs are validated against the live page before execution, writes are verified via snapshot diff, and outcomes are computed from an evidence ledger rather than the model's own claim. ![GitHub Repo stars](https://img.shields.io/github/stars/Cyrus580529/Attest?style=social)
+- [Attest](https://github.com/Cyrus580529/Attest) - Library for web agents that validates each action against the live page before running it, verifies the result with a snapshot diff, and logs an evidence ledger so what an agent claims to have done is provable, not just asserted. ![GitHub Repo stars](https://img.shields.io/github/stars/Cyrus580529/Attest?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Summary
Adds Attest, a TypeScript trust layer for web agents that verifies agent-proposed actions against real page state and computes task outcomes from an evidence ledger instead of trusting the model's own report.

## Item
- Name: Attest
- Link: https://github.com/Cyrus580529/Attest

## Section
Dev Tools

## Why this belongs
Attest is a library for building web agents that must be auditable: every ref an agent proposes is validated against the live page before execution (no guessed selectors), every write is verified via a before/after snapshot diff, and the final outcome (completed/failed/cancelled) is computed from that evidence ledger rather than the model's self-report. It also integrates with ST-WebAgentBench (ICLR'26) for real trust/safety benchmarking of web agents.

## Primary documented web-agent use case
README: https://github.com/Cyrus580529/Attest#readme — the whole project exists specifically to drive web pages (VOIX-standard or data-agent-* declared pages) with verified, auditable actions.

## Public reference
https://github.com/Cyrus580529/Attest

## Affiliation disclosure
Yes — I am the author/maintainer of this project.

## Checklist
- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.