### PR TITLE
Add: Webfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [BrowserAct](https://github.com/browser-act/skills) - Browser automation CLI and skills for AI agents to operate real browsers, manage sessions, support human handoff, and capture screenshots and evidence. ![GitHub Repo stars](https://img.shields.io/github/stars/browser-act/skills?style=social)
 - [Agent Browser Shield](https://github.com/pixiebrix/agent-browser-shield) - Browser extension that sits between an AI agent and the page, stripping prompt injection, masking PII/credentials, and removing dark patterns before content reaches the model. ![GitHub Repo stars](https://img.shields.io/github/stars/pixiebrix/agent-browser-shield?style=social)
 - [HUD](https://github.com/hud-evals/hud-python) - Open-source SDK for building browser and computer-use RL environments to evaluate and train web agents, with task-based verifiable rewards runnable as evals or RL training across any model. ![GitHub Repo stars](https://img.shields.io/github/stars/hud-evals/hud-python?style=social)
+- [Webfuse](https://www.webfuse.com) - Configurable web proxy and browser-as-a-service for deploying and operating AI agents in a sandbox layer on top of any third-party website, using client-side extensions and without source-code access.
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Summary

Adds Webfuse, a configurable web proxy and browser-as-a-service, to the Dev Tools subsection as infrastructure for deploying and running AI agents on top of any website.

## Item

- Name: Webfuse
- Link: https://www.webfuse.com

## Section

Dev Tools

## Why this belongs

Webfuse is infrastructure for operating web agents. It serves any website through a programmable proxy (a virtual browser you can embed in a real browser) and lets you inject client-side extensions on top of it without access to the original site's source code. One of its documented primary use cases is deploying AI agents in a sandbox layer on top of third-party websites, which is the same "run and operate agents on the live web" role filled by other Dev Tools entries such as Browserbase, Notte, and Steel.dev.

## Primary documented web-agent use case

The Webfuse use cases page lists "Deploy AI Agents: reuse and deploy AI agents in a sandbox layer on top of any website" as a primary use case: https://www.webfuse.com/use-cases

Product and technical docs: https://docs.webfuse.com

## Public reference

- https://www.webfuse.com
- https://docs.webfuse.com
- https://www.webfuse.com/use-cases

## Affiliation disclosure

Yes, I am affiliated. Webfuse is a product of Surfly and I work at Surfly, so please weigh the neutrality of the description accordingly. I have tried to keep it factual and non-promotional and am happy to adjust the wording or section if you prefer.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.
