### PR TITLE
Remove Surf.new link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Steel is an [open-source](https://github.com/steel-dev/steel-browser) browser AP
 
 AI agents that autonomously navigate and interact with the web through a user-friendly interface. (a.k.a Browser Agents)
 
-- [Surf.new](https://surf.new) - An open-source playground for chatting with different web agents. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/surf.new?style=social)
 - [OpenAI Operator](https://openai.com/index/introducing-operator/) - OpenAI's AI agents that can browse the web for you.
 - [Browser-Use](https://www.browser-use.com) - SOTA agent and framework that makes the web LLM-friendly. ![GitHub Repo stars](https://img.shields.io/github/stars/Browser-Use/browser-use?style=social)
 - [Skyvern-AI](https://www.skyvern.com/) - Framework to automate browser-based workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/Skyvern-AI/skyvern?style=social)


### PR DESCRIPTION
Removed the link to Surf.new from the list of autonomous web agents. The website's down.

The website for Surf.new is down so I am proposing to remove this to keep the list up to date with the latest tools. This is specifically for autonomous web agents