### PR TITLE
Add: Hermes Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [HUD](https://github.com/hud-evals/hud-python) - Open-source SDK for building browser and computer-use RL environments to evaluate and train web agents, with task-based verifiable rewards runnable as evals or RL training across any model. ![GitHub Repo stars](https://img.shields.io/github/stars/hud-evals/hud-python?style=social)
 - [Webfuse](https://www.webfuse.com) - Configurable web proxy and browser-as-a-service for deploying and operating AI agents in a sandbox layer on top of any third-party website, using client-side extensions and without source-code access.
 - [Webcmd](https://github.com/agentrhq/webcmd) - Self-learning browser infrastructure for AI agents that records how a site is navigated, then compiles that context into deterministic CLI adapters and reusable sitemap memory for later runs. ![GitHub Repo stars](https://img.shields.io/github/stars/agentrhq/webcmd?style=social)
-- [Hermes Connector](https://github.com/CorsenAI/hermes-connector) - Open-source Chrome extension and local companion that let Hermes Agent control only explicitly attached tabs in a user's Chrome session. ![GitHub Repo stars](https://img.shields.io/github/stars/CorsenAI/hermes-connector?style=social)
+- [Hermes Connector](https://github.com/CorsenAI/hermes-connector) - Unofficial open-source Chrome extension and local companion that let Hermes Agent control only explicitly attached tabs in a user's Chrome session. ![GitHub Repo stars](https://img.shields.io/github/stars/CorsenAI/hermes-connector?style=social)
 
 ## AI Web Scrapers/Crawlers
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Tools, frameworks and libraries that translate natural language instructions int
 - [HUD](https://github.com/hud-evals/hud-python) - Open-source SDK for building browser and computer-use RL environments to evaluate and train web agents, with task-based verifiable rewards runnable as evals or RL training across any model. ![GitHub Repo stars](https://img.shields.io/github/stars/hud-evals/hud-python?style=social)
 - [Webfuse](https://www.webfuse.com) - Configurable web proxy and browser-as-a-service for deploying and operating AI agents in a sandbox layer on top of any third-party website, using client-side extensions and without source-code access.
 - [Webcmd](https://github.com/agentrhq/webcmd) - Self-learning browser infrastructure for AI agents that records how a site is navigated, then compiles that context into deterministic CLI adapters and reusable sitemap memory for later runs. ![GitHub Repo stars](https://img.shields.io/github/stars/agentrhq/webcmd?style=social)
+- [Hermes Connector](https://github.com/CorsenAI/hermes-connector) - Open-source Chrome extension and local companion that let Hermes Agent control only explicitly attached tabs in a user's Chrome session. ![GitHub Repo stars](https://img.shields.io/github/stars/CorsenAI/hermes-connector?style=social)
 
 ## AI Web Scrapers/Crawlers
 


### PR DESCRIPTION
## Summary

Adds Hermes Connector to the Dev Tools section. It is an open-source Chrome extension and local companion that bridges Hermes Agent to explicitly attached tabs in an existing Chrome profile.

## Item

- Name: Hermes Connector
- Link: https://github.com/CorsenAI/hermes-connector

## Section

Dev Tools

## Why this belongs

Hermes Connector is browser-control infrastructure for running Hermes Agent against selected web pages. The public README documents page inspection, navigation, clicking, typing, scrolling, tab management, and screenshots, with access limited to tabs the user explicitly attaches. Dev Tools is the best fit because the project supplies the browser connection and control layer rather than a standalone autonomous agent.

## Primary documented web-agent use case

The README documents the primary workflow and supported browser operations: https://github.com/CorsenAI/hermes-connector#your-hermes-session-inside-the-chrome-you-already-use

## Public reference

- Source and technical overview: https://github.com/CorsenAI/hermes-connector
- Setup documentation: https://corsenai.github.io/hermes-connector/
- Public Chrome Web Store listing: https://chromewebstore.google.com/detail/hermes-connector-%E2%80%94-by-cor/cdhaldcgafmkcnpanlmmpaebabnlledm

## Affiliation disclosure

Yes. This PR is submitted from the CorsenAI GitHub account, which owns and maintains Hermes Connector.

## Checklist

- [x] This PR adds exactly one item.
- [x] I added the item to the bottom of the best-fit section.
- [x] The description is factual, neutral, and ends with a period.
- [x] This is directly relevant to web agents, not just AI tooling in general.
- [x] I checked for duplicates before submitting.
